### PR TITLE
Add URL rewrite filter

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/RewriteURLFilter.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RewriteURLFilter.java
@@ -1,0 +1,62 @@
+/**
+ * RewriteURLFilter.java
+ * 05/27/2020
+ *
+ * @author Alexander Luiz Costa
+ */
+package com.google.sps.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Strips a request URL of any file extensions and/or extra forward slashes
+ * and performs necessary server-side forwarding. Operates on all requests
+ * to the webserver.
+ */
+@WebFilter("/*")
+public class RewriteURLFilter implements Filter {
+  @Override
+  public void init(FilterConfig config) throws ServletException {}
+  
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+    throws ServletException, IOException {
+    HttpServletRequest request = (HttpServletRequest) req;
+    HttpServletResponse response = (HttpServletResponse) res;
+    String uri = request.getRequestURI();
+
+    // client-side forwarding (modifies url of client browser)
+    if (uri.contains(".html")) {
+      response.sendRedirect(uri.replace(".html", ""));
+      return;
+    }
+    if (uri.endsWith("/") && !uri.equals("/")) {
+      response.sendRedirect(uri.substring(0, uri.length() - 1));
+      return;
+    }
+
+    // server-side forwarding (will not change url of client browser)
+    // dynamic pages (e.g. /projects) are handled by a servlet
+    switch (uri) {
+    case "/index":
+    case "/about":
+    case "/social":
+      request.getRequestDispatcher(uri + ".html").forward(req, res);
+      break;
+    default:
+      chain.doFilter(req, res);
+      break;
+    }
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/RewriteURLFilter.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RewriteURLFilter.java
@@ -26,37 +26,43 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebFilter("/*")
 public class RewriteURLFilter implements Filter {
+
+  // Must provide concrete implementation to avoid AbstractMethodError.
   @Override
   public void init(FilterConfig config) throws ServletException {}
   
   @Override
   public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
     throws ServletException, IOException {
-    HttpServletRequest request = (HttpServletRequest) req;
-    HttpServletResponse response = (HttpServletResponse) res;
-    String uri = request.getRequestURI();
+    if (req instanceof HttpServletRequest && res instanceof HttpServletResponse) {
+      HttpServletRequest request = (HttpServletRequest) req;
+      HttpServletResponse response = (HttpServletResponse) res;
+      String uri = request.getRequestURI();
 
-    // client-side forwarding (modifies url of client browser)
-    if (uri.contains(".html")) {
-      response.sendRedirect(uri.replace(".html", ""));
-      return;
-    }
-    if (uri.endsWith("/") && !uri.equals("/")) {
-      response.sendRedirect(uri.substring(0, uri.length() - 1));
-      return;
-    }
+      // Client-side forwarding (modifies url of client browser).
+      if (uri.contains(".html")) {
+        response.sendRedirect(uri.replace(".html", ""));
+        return;
+      }
+      if (uri.endsWith("/") && !uri.equals("/")) {
+        response.sendRedirect(uri.substring(0, uri.length() - 1));
+        return;
+      }
 
-    // server-side forwarding (will not change url of client browser)
-    // dynamic pages (e.g. /projects) are handled by a servlet
-    switch (uri) {
-    case "/index":
-    case "/about":
-    case "/social":
-      request.getRequestDispatcher(uri + ".html").forward(req, res);
-      break;
-    default:
+      // Server-side forwarding (will not change url of client browser).
+      // Dynamic pages (e.g. /projects) are handled by a servlet.
+      switch (uri) {
+      case "/index":
+      case "/about":
+      case "/social":
+        request.getRequestDispatcher(uri + ".html").forward(req, res);
+        break;
+      default:
+        chain.doFilter(req, res);
+        break;
+      }
+    } else {
       chain.doFilter(req, res);
-      break;
     }
   }
 }

--- a/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
@@ -8,5 +8,9 @@
   <static-files>
     <!-- prevent unwanted caching when accessing via the web preview server -->
     <include path="/**" expiration="0s" />
+    
+    <!-- prevent html files from being served without going through URL rewrite filter -->
+    <exclude path="/**.html" />
+    <exclude path="/**.html/**" />
   </static-files>
 </appengine-web-app>


### PR DESCRIPTION
Normalize (and make prettier) the URL of incoming requests.

Add a web filter for all incoming requests to strip the request URL of any file extensions and/or extra forward slashes. Perform necessary server-side and client-side forwarding. Modify appengine-web.xml to exclude html files from static content to prevent App Engine from serving html files without first routing the incoming request through the RewriteURLFilter. 