### PR TITLE
Add servlet for dynamic visualizations page

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
@@ -1,0 +1,67 @@
+/**
+ * VisualizationsServlet.java
+ * 05/27/2020
+ * 
+ * @author Alexander Luiz Costa
+ */
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Dynamically assembles the different endpoints of the "/visualizations" page.
+ */
+@WebServlet("/visualizations/*")
+public class VisualizationsServlet extends HttpServlet {
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws IOException, ServletException {
+    
+    String visualization = request.getPathInfo();
+
+    // let the default visualzation be the sorting visualizations
+    if (visualization == null || visualization.equals("/")) {
+      visualization = "/sorting";
+    }
+
+    // gather the visualizations content which will be
+    // inserted into the visualizations template page
+    List<String> content;
+    switch (visualization) {
+    case "/sorting":
+    case "/searching":
+      content = Files.readAllLines(Paths.get("data/visualizations" + visualization + ".html"),
+                                   StandardCharsets.UTF_8);
+      break;
+    default:
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
+      return;
+    }
+
+    List<String> template = Files.readAllLines(Paths.get("visualizations.html"),
+                                               StandardCharsets.UTF_8);
+
+    // assemble the response
+    for (String line : html) {
+      response.getWriter().println(line);
+      
+      if (line.trim().equals("<div class=\"ten columns content-sidebar\">")) {
+        for (String contentLine : content) {
+          response.getWriter().println(contentLine);
+        }
+      }
+    }
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
@@ -31,14 +31,14 @@ public class VisualizationsServlet extends HttpServlet {
     
     String visualization = request.getPathInfo();
 
-    // let the default visualzation be the sorting visualizations
+    // Default visualization is sorting visualization.
     if (visualization == null || visualization.equals("/")) {
       visualization = "/sorting";
     }
 
-    // gather the visualizations content which will be
-    // inserted into the visualizations template page
-    List<String> content;
+    // Gather the visualizations content which will be inserted into
+    // the visualizations template page.
+    List<String> content = new ArrayList<>();
     switch (visualization) {
     case "/sorting":
     case "/searching":
@@ -53,7 +53,6 @@ public class VisualizationsServlet extends HttpServlet {
     List<String> template = Files.readAllLines(Paths.get("visualizations.html"),
                                                StandardCharsets.UTF_8);
 
-    // assemble the response
     for (String line : html) {
       response.getWriter().println(line);
       


### PR DESCRIPTION
Add servlet to receive visualizations page requests and assemble a dynamic response.

Dynamically inserts visualization content into a visualization page template document depending on the request URL. Defaults to the sorting algorithm visualization and returns a 404 error if an invalid visualization is requested.