### PR TITLE
Add onload animations script

### DIFF
--- a/portfolio/src/main/webapp/js/onload-animations.js
+++ b/portfolio/src/main/webapp/js/onload-animations.js
@@ -31,7 +31,7 @@ window.addEventListener("DOMContentLoaded", () => {
  */
 function fadeShiftContent() {
     const body = document.querySelectorAll(".bp")
-    for (var i = 0; i < body.length; i++) {
+    for (let i = 0; i < body.length; i++) {
         body[i].id = "bp" + i
         Animator.queue(new FadeShift(body[i], 1, 0.1, 'y', 24, 0, -1.6))
     }
@@ -45,7 +45,7 @@ function fadeShiftContent() {
  */
 function fadeShiftSidebar() {
     const links = document.querySelectorAll("[sidebar]")
-    for (var i = 0; i < links.length; i++) {
+    for (let i = 0; i < links.length; i++) {
         links[i].id = "sidebar" + i
         Animator.queue(new FadeShift(links[i], 1, 0.1, "x", 24, 0, -1.6), i * 100)
     }

--- a/portfolio/src/main/webapp/js/onload-animations.js
+++ b/portfolio/src/main/webapp/js/onload-animations.js
@@ -5,59 +5,50 @@
  * @author Alexander Luiz Costa
  */
 
-/**
+/*
  * Starts the appropriate page load animations on DOMContentLoaded
  * event.
  */
-window.addEventListener("DOMContentLoaded", () => {
-    if (document.querySelector(".bp")) {
-        fadeShiftContent()
-    }
+window.addEventListener('DOMContentLoaded', () => {
+  if (document.querySelector('.bp')) {
+    fadeShiftContent();
+  }
 
-    if (document.querySelector("[sidebar]")) {
-        fadeShiftSidebar()
-    }
+  if (document.querySelector('[sidebar]')) {
+    fadeShiftSidebar();
+  }
 
-    if (document.querySelector(".socials")) {
-        fadeShiftSocials()
-    }
-})
+  if (document.querySelector('.socials')) {
+    fadeShiftSocials();
+  }
+});
 
 /**
- * Fades in and shifts up any elements of class "bp".
- * 
- * Can be called from within script tags to execute on page
- * load.
+ * Fades in and shifts up any elements of class `bp`.
  */
 function fadeShiftContent() {
-    const body = document.querySelectorAll(".bp")
-    for (let i = 0; i < body.length; i++) {
-        body[i].id = "bp" + i
-        Animator.queue(new FadeShift(body[i], 1, 0.1, 'y', 24, 0, -1.6))
-    }
+  const body = document.querySelectorAll('.bp');
+  for (let i = 0; i < body.length; i++) {
+    body[i].id = 'bp' + i;
+    Animator.queue(new FadeShift(body[i], 1, 0.1, 'y', 24, 0, -1.6));
+  }
 }
 
 /**
  * Fades in and shifts left any sidebar links.
- * 
- * Can be called from within script tags to execute on page
- * load.
  */
 function fadeShiftSidebar() {
-    const links = document.querySelectorAll("[sidebar]")
-    for (let i = 0; i < links.length; i++) {
-        links[i].id = "sidebar" + i
-        Animator.queue(new FadeShift(links[i], 1, 0.1, "x", 24, 0, -1.6), i * 100)
-    }
+  const links = document.querySelectorAll('[sidebar]');
+  for (let i = 0; i < links.length; i++) {
+    links[i].id = 'sidebar' + i;
+    Animator.queue(new FadeShift(links[i], 1, 0.1, 'x', 24, 0, -1.6), i * 100);
+  }
 }
 
 /**
  * Fades in and shifts up any social links.
- * 
- * Can be called from within script tags to execute on page
- * load.
  */
 function fadeShiftSocials() {
-    const socials = document.querySelector(".socials")
-    Animator.queue(new FadeShift(socials, 1, 0.1, 'y', 24, 0, -1.6))
+  const socials = document.querySelector('.socials');
+  Animator.queue(new FadeShift(socials, 1, 0.1, 'y', 24, 0, -1.6));
 }

--- a/portfolio/src/main/webapp/js/onload-animations.js
+++ b/portfolio/src/main/webapp/js/onload-animations.js
@@ -1,0 +1,63 @@
+/**
+ * onload-animations.js
+ * 05/29/2020
+ *
+ * @author Alexander Luiz Costa
+ */
+
+/**
+ * Starts the appropriate page load animations on DOMContentLoaded
+ * event.
+ */
+window.addEventListener("DOMContentLoaded", () => {
+    if (document.querySelector(".bp")) {
+        fadeShiftContent()
+    }
+
+    if (document.querySelector("[sidebar]")) {
+        fadeShiftSidebar()
+    }
+
+    if (document.querySelector(".socials")) {
+        fadeShiftSocials()
+    }
+})
+
+/**
+ * Fades in and shifts up any elements of class "bp".
+ * 
+ * Can be called from within script tags to execute on page
+ * load.
+ */
+function fadeShiftContent() {
+    const body = document.querySelectorAll(".bp")
+    for (var i = 0; i < body.length; i++) {
+        body[i].id = "bp" + i
+        Animator.queue(new FadeShift(body[i], 1, 0.1, 'y', 24, 0, -1.6))
+    }
+}
+
+/**
+ * Fades in and shifts left any sidebar links.
+ * 
+ * Can be called from within script tags to execute on page
+ * load.
+ */
+function fadeShiftSidebar() {
+    const links = document.querySelectorAll("[sidebar]")
+    for (var i = 0; i < links.length; i++) {
+        links[i].id = "sidebar" + i
+        Animator.queue(new FadeShift(links[i], 1, 0.1, "x", 24, 0, -1.6), i * 100)
+    }
+}
+
+/**
+ * Fades in and shifts up any social links.
+ * 
+ * Can be called from within script tags to execute on page
+ * load.
+ */
+function fadeShiftSocials() {
+    const socials = document.querySelector(".socials")
+    Animator.queue(new FadeShift(socials, 1, 0.1, 'y', 24, 0, -1.6))
+}

--- a/portfolio/src/main/webapp/js/onload-animations.js
+++ b/portfolio/src/main/webapp/js/onload-animations.js
@@ -9,7 +9,7 @@
  * Starts the appropriate page load animations on DOMContentLoaded
  * event.
  */
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
   if (document.querySelector('.bp')) {
     fadeShiftContent();
   }

--- a/portfolio/src/main/webapp/js/onload-animations.js
+++ b/portfolio/src/main/webapp/js/onload-animations.js
@@ -30,7 +30,15 @@ function fadeShiftContent() {
   const body = document.querySelectorAll('.bp');
   for (let i = 0; i < body.length; i++) {
     body[i].id = 'bp' + i;
-    Animator.queue(new FadeShift(body[i], 1, 0.1, 'y', 24, 0, -1.6));
+    Animator.queue(new FadeShift(
+      /* node= */ body[i],
+      /* fadeTo= */ 1,
+      /* fadeStep= */ 0.1,
+      /* shiftAxis= */ 'y',
+      /* shiftFrom= */ 24,
+      /* shiftTo= */ 0,
+      /* shiftStep */ -1.6,
+    ));
   }
 }
 
@@ -41,7 +49,15 @@ function fadeShiftSidebar() {
   const links = document.querySelectorAll('[sidebar]');
   for (let i = 0; i < links.length; i++) {
     links[i].id = 'sidebar' + i;
-    Animator.queue(new FadeShift(links[i], 1, 0.1, 'x', 24, 0, -1.6), i * 100);
+    Animator.queue(new FadeShift(
+      /* node= */ links[i],
+      /* fadeTo= */ 1,
+      /* fadeStep= */ 0.1,
+      /* shiftAxis= */ 'x',
+      /* shiftFrom= */ 24,
+      /* shiftTo= */ 0,
+      /* shiftStep */ -1.6,
+    ), /* delay= */ i * 100);
   }
 }
 
@@ -50,5 +66,13 @@ function fadeShiftSidebar() {
  */
 function fadeShiftSocials() {
   const socials = document.querySelector('.socials');
-  Animator.queue(new FadeShift(socials, 1, 0.1, 'y', 24, 0, -1.6));
+  Animator.queue(new FadeShift(
+    /* node= */ socials,
+    /* fadeTo= */ 1,
+    /* fadeStep= */ 0.1,
+    /* shiftAxis= */ 'y',
+    /* shiftFrom= */ 24,
+    /* shiftTo= */ 0,
+    /* shiftStep */ -1.6,
+  ));
 }


### PR DESCRIPTION
Add a script to handle the simple page load animations.

This script will be included in all html pages. The script registers an even handler for the DOMContentLoaded event, upon which the appropriate fade shift animations will be started according to which DOM elements are found in the html document.