### PR TITLE
Fix unresolved reference to variable 'html'

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/VisualizationsServlet.java
@@ -53,7 +53,7 @@ public class VisualizationsServlet extends HttpServlet {
     List<String> template = Files.readAllLines(Paths.get("visualizations.html"),
                                                StandardCharsets.UTF_8);
 
-    for (String line : html) {
+    for (String line : template) {
       response.getWriter().println(line);
       
       if (line.trim().equals("<div class=\"ten columns content-sidebar\">")) {


### PR DESCRIPTION
Did not fully rename variable "html" to "template", leaving unresolved references to variable "html". Here we fully update all references of "html" to "template".