### PR TITLE
Add custom datastore indexes for comment/reply queries

### DIFF
--- a/portfolio/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/portfolio/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<datastore-indexes autoGenerate="true">
+  <datastore-index kind="Comment" ancestor="false" source="auto">
+    <property name="parentId" direction="asc"/>
+    <property name="project" direction="asc"/>
+    <property name="timestamp" direction="desc"/>
+  </datastore-index>
+  <datastore-index kind="Comment" ancestor="false" source="auto">
+    <property name="parentId" direction="asc"/>
+    <property name="timestamp" direction="asc"/>
+  </datastore-index>
+</datastore-indexes>


### PR DESCRIPTION
These custom indexes are necessary for the deployed application to fulfill comment/reply queries. The development server auto-generates these indexes, but the deployed application does not.