### PR TITLE
Add authentication to comment votes

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -9,6 +9,7 @@
 package com.google.sps.data;
 
 import com.google.appengine.api.datastore.Entity;
+import java.util.List;
 
 /**
  * A user comment or reply to a comment on a projects page.
@@ -50,6 +51,12 @@ public class Comment {
    */
   private final long replyCount;
 
+  /** A list of users who have liked this comment. */
+  private final List<String> likeUsers;
+
+  /** A list of users who have disliked this comment. */  
+  private final List<String> dislikeUsers;
+
   /**
    * Constructs a new comment instance from a Datastore entity.
    * @see com.google.appengine.api.datastore.Entity
@@ -65,11 +72,9 @@ public class Comment {
     this.dislikes = (long) entity.getProperty("dislikes");
     this.timestamp = (long) entity.getProperty("timestamp");
     this.parentId = (long) entity.getProperty("parentId");
-    if (this.parentId == -1) {
-      replyCount = (long) entity.getProperty("replyCount");
-    } else {
-      replyCount = 0;
-    }
+    this.replyCount = (long) entity.getProperty("replyCount");
+    this.likeUsers = (List) entity.getProperty("likeUsers");
+    this.dislikeUsers = (List) entity.getProperty("dislikeUsers");
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/CreateCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CreateCommentServlet.java
@@ -19,6 +19,7 @@ import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.servlet.annotation.WebServlet;
@@ -66,6 +67,12 @@ public class CreateCommentServlet extends HttpServlet {
     long timestamp = System.currentTimeMillis();
     long parentId = Long.parseLong(request.getParameter("parentId"));
     long replyCount = 0;
+    List<String> likeUsers = new ArrayList<>();
+    List<String> dislikeUsers = new ArrayList<>();
+    
+    // Avoid empty lists being stored as null properties in Datastore.
+    likeUsers.add("ignore");
+    dislikeUsers.add("ignore");
 
     // Parse the referring url to determine to which project page this
     // comment belongs.
@@ -92,6 +99,8 @@ public class CreateCommentServlet extends HttpServlet {
     comment.setProperty("parentId", parentId);
     comment.setProperty("project", project);
     comment.setProperty("replyCount", replyCount);
+    comment.setProperty("likeUsers", likeUsers);
+    comment.setProperty("dislikeUsers", dislikeUsers);
     datastore.put(comment);
 
     if (parentId != -1) {


### PR DESCRIPTION
Add authentication checks to comment likes/dislikes. Additionally, limits users to one vote (like or dislike) per comment.