### PR TITLE
Implement consideration for optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/pom.xml
+++ b/walkthroughs/week-5-tdd/project/pom.xml
@@ -38,6 +38,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Consider optional attendees when choosing open time slots. If consideration of optional attendees results in no open time slots, reconsider using only mandatory attendees.